### PR TITLE
refactor: updated setting delegation steps

### DIFF
--- a/docs/commands/staker/set-delegation.md
+++ b/docs/commands/staker/set-delegation.md
@@ -40,5 +40,5 @@ $ docker exec -it razor-go razor updateCommission --address 0x5a0b54d5dc17e0aadc
 
 Enable delegation:
 ```
-$ docker exec -it razor-go razor --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true --logFile logs
+$ docker exec -it razor-go razor setDelegation --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true --logFile logs
 ```

--- a/docs/commands/staker/set-delegation.md
+++ b/docs/commands/staker/set-delegation.md
@@ -3,22 +3,42 @@ title: Set Delegation
 ---
 
 If you are a staker you can accept delegation from delegators and charge a commission from them.
+Setting up delegation involves two primary commands:
 
-razor cli
+1. **Update Commission**: First, the staker must specify their desired commission rate. This is done using the `updateCommission` command with the `--commission` flag.
+2. **Set Delegation**: Next, the staker must enable or disable delegation using the `setDelegation` command with the `--status` flag. To enable delegation, pass `--status true`.
 
+### Using razor CLI
+
+To update the commission:
 ```
-$ ./razor setDelegation --address <address> --status <true_or_false> --commission <commission_percent> --logFile <filename>
-```
-
-docker
-
-```
-docker exec -it razor-go razor
-    setDelegation --address <address> --status <true_or_false> --commission <commission_percent> --logFile <filename>
+$ ./razor updateCommission --address <address> --commission <commission_percent> --logFile <filename>
 ```
 
-Example:
-
+To set delegation status:
 ```
-$ ./razor setDelegation --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true -c 20 --logFile logs
+$ ./razor setDelegation --address <address> --status <true_or_false> --logFile <filename>
+```
+
+### Using Docker
+
+To update the commission:
+```
+docker exec -it razor-go razor updateCommission --address <address> --commission <commission_percent> --logFile <filename>
+```
+
+To set delegation status:
+```
+docker exec -it razor-go razor setDelegation --address <address> --status <true_or_false> --logFile <filename>
+```
+
+#### Example:
+Update the commission:
+```
+$ docker exec -it razor-go razor updateCommission --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --commission 10 --logFile logs
+```
+
+Enable delegation:
+```
+$ docker exec -it razor-go razor --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true --logFile logs
 ```

--- a/docs/stake.md
+++ b/docs/stake.md
@@ -187,15 +187,7 @@ Example:
 $ ./razor addStake --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --value 5678100100000000000000 --weiRazor true
 ```
 
-To start accepting delegation, use the delegation command in a new terminal:
-
-    docker exec -it razor-go razor setDelegation --address <address> --status <bool> --commission <commission> --logFile <filename>
-
-where `address` is the address that contains RAZOR tokens, `status` is true or false to turn on or off delegation, and `commission` is the percentage of commission that you can set.
-
-An example of this command would be:
-
-    docker exec -it razor-go razor setDelegation --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --status true --commission 20 --logFile logs
+To start accepting delegation, use the delegation command in a new terminal which mentioned in the [set delegation documentation](https://docs.razor.network/docs/commands/staker/set-delegation)
 
 It will enable delegation, and participants can delegate RAZOR tokens to your staker's account.
 

--- a/docs/stake.md
+++ b/docs/stake.md
@@ -187,7 +187,7 @@ Example:
 $ ./razor addStake --address 0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c --value 5678100100000000000000 --weiRazor true
 ```
 
-To start accepting delegation, use the delegation command in a new terminal which mentioned in the [set delegation documentation](https://docs.razor.network/docs/commands/staker/set-delegation)
+To start accepting delegation, use the delegation command in a new terminal which is mentioned in the [set delegation documentation](https://docs.razor.network/docs/commands/staker/set-delegation)
 
 It will enable delegation, and participants can delegate RAZOR tokens to your staker's account.
 


### PR DESCRIPTION
As there was a need to update setting delegation steps from only using setDelegation command to the alternative steps mentioned below:

```
First stakers will use the `updateCommission` command to just update commission
and secondly stakers will use `setDelegation` command to only set the delegation status
```